### PR TITLE
Tweak the backoff numbers.

### DIFF
--- a/bubbles.go
+++ b/bubbles.go
@@ -35,10 +35,10 @@ const (
 	DefaultConnCount = 2
 
 	// backoffTimeoutRatio determines when we start backing off.
-	backoffTimeoutRatio = 2
+	backoffTimeoutRatio = 6
 
-	serverErrorWait    = 500 * time.Millisecond
-	serverErrorWaitMax = 16 * time.Second
+	serverErrorWait    = 50 * time.Millisecond
+	serverErrorWaitMax = 10 * time.Second
 
 	defaultElasticSearchPort = "9200"
 )


### PR DESCRIPTION
If the quit thing is good, we should reconsider the timeout ratio here.

Commit message:

For something we do regularly on slow requests, the first backoff step
from 0ms to 500ms is way too high: Two levels of backup would cut us
to ~600 documents per second.

In case of real errors, I think the low backoff to start should still
be enough. Alternatively, we might want to separate the error backoff from
the tuning backoff. And maybe rather make the tuning backoff linear, in
terms of time at least.
